### PR TITLE
woff files not working in IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ function fontawesomeSubset(subset, output_dir, options){
 
         fs.writeFileSync(`${output_file}.svg`, svg_contents_new);
         fs.writeFileSync(`${output_file}.ttf`, ttf);
-        fs.writeFileSync(`${output_file}.eot`, ttf2eot(ttf));
-        fs.writeFileSync(`${output_file}.woff`, ttf2woff(ttf));
+        fs.writeFileSync(`${output_file}.eot`, new Buffer(ttf2eot(ttf_utils).buffer));
+        fs.writeFileSync(`${output_file}.woff`, new Buffer(ttf2woff(ttf_utils).buffer));
         fs.writeFileSync(`${output_file}.woff2`, ttf2woff2(ttf));
     }
 }


### PR DESCRIPTION
We noticed that woff files don't work in IE11.
ttf2woff expects an array as parameter. The buffer leads to a broken woff file. 
the same applies to eot (untested)