### PR TITLE
Refactor FontAwesome Icon Parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ charset = utf-8
 end_of_line = lf
 indent_size = 4
 indent_style = space
-insert_final_newline = false
+insert_final_newline = true
 max_line_length = 500
 tab_width = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0](https://github.com/omacranger/fontawesome-subset/compare/3.0.0...4.0.0)
+- Update minimum FontAwesome NPM dependencies to >=5.12.0.
+- Upgrade parsing system to use icon metadata YAML instead of parsing SVGs. This also fixes FontAwesome 6.0 support ( Resolves #15 & #16 )
+- Replace manual usage of node_modules with `require.resolve` ( Resolves #17 )
+
+## [3.0.0](https://github.com/omacranger/fontawesome-subset/compare/2.0.0...3.0.0)
+- Update default export to be an object for better future maintainability & modern tooling. See [the upgrade guide](UPGRADING.md) for further details.
+- Update all dependencies to latest versions ( Resolves #13 )
+- Remove default timestamp on fonts to ensure deterministic output ( Resolves #11 )
+
 ## [2.0.0](https://github.com/omacranger/fontawesome-subset/compare/1.1.0...2.0.0)
 - Remove required `@fortawesome/fontawesome-free` dependency. Must install a needed version manually and define the package type in the options object. Defaults to `free`. See [the upgrade guide](UPGRADING.md) for further details.
 - Refactored module to TypeScript

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ First, install fontawesome-subset:
 npm install --save-dev fontawesome-subset
 ```
 
-Second, install the edition of FontAwesome you plan on using. **Versions 5.12 and up are currently supported.** If you're using the Pro version, see [below](#using-with-fontawesome-pro). For the free version, use the following:
+Second, install the edition of FontAwesome you plan on using. **Versions >=5.12.0 are currently supported.** If you're using the Pro version, see [below](#using-with-fontawesome-pro). For the free version, use the following:
 
 ```sh
 npm install --save-dev @fortawesome/fontawesome-free

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Love FontAwesome but don't need thousands of icons bundled on every page of the 
 ## Installation
 First, install fontawesome-subset:
 ```sh
-npm install --save-dev fontawesome-subset 
+npm install --save-dev fontawesome-subset
 ```
 
-Second, install the edition of FontAwesome you plan on using. If you're using the Pro version, see [below](#using-with-fontawesome-pro). For the free version, use the following:
+Second, install the edition of FontAwesome you plan on using. **Versions 5.12 and up are currently supported.** If you're using the Pro version, see [below](#using-with-fontawesome-pro). For the free version, use the following:
+
 ```sh
 npm install --save-dev @fortawesome/fontawesome-free
 ```
@@ -26,14 +27,14 @@ fontawesomeSubset(['check','square','caret-up'], 'sass/webfonts');
 ### Full Options
 
 #### fontawesomeSubset(subset, output_dir, options)
-- `subset` - Array containing list of glyph names (icon names) that you want to limit the subset to. When using FontAwesome Pro (see [below](#using-with-fontawesome-pro)) you can supply an object with key->value pairs for different FA styles (solid, regular, light, brands, duotone).
+- `subset` - Array containing list of glyph names (icon names) that you want to generate for the `solid` style. This can also be an object with key->value pairs for different FA styles (solid, regular¹, brands, light¹, duotone¹). Some Icons in these **¹** subsets are only available when used with FontAwesome Pro (see [below](#using-with-fontawesome-pro)).
 - `output_dir` - Directory that you want the webfonts to be generated in. Relative to current NPM process. Ex: `sass/webfonts`
 - `options` - Object of options to further customize the tool.
     - `package` - `free` or `pro` . Defaults to `free` version. See [below](#using-with-fontawesome-pro) for Pro instructions.
     
     
 ### Using with FontAwesome Pro
-FontAwesome (FA) Pro provides numerous additional icons, as well as different font weights (styles) that you can use. Obviously, you'll need to own the 'Pro' version of FA in order to use with this subsetting tool. If you've already purchased a license, follow the [installation instructions](https://fontawesome.com/how-to-use/on-the-web/setup/using-package-managers) for getting FontAwesome Pro up and running through NPM.
+FontAwesome (FA) Pro provides numerous additional icons, as well as additional font weights & styles that you can use. Obviously, you'll need to own the 'Pro' version of FA in order to use with this subsetting tool. If you've already purchased a license, follow the [installation instructions](https://fontawesome.com/docs/web/setup/packages) for getting FontAwesome Pro up and running through NPM.
 
 After installation, you can supply additional information to the `subset` parameter of `fontawesomeSubset` to create families for specific font styles. Make sure to include `package: 'pro'` inside the options parameter to generate from the Pro source instead and enable font creation for different weights / styles. 
 
@@ -55,15 +56,9 @@ The above example would output a directory with the following structure:
 ```
 /sass/
     /webfonts/
-        fa-regular-400.eot
-        fa-regular-400.svg
         fa-regular-400.ttf
-        fa-regular-400.woff
         fa-regular-400.woff2
-        fa-solid-900.eot
-        fa-solid-900.svg
         fa-solid-900.ttf
-        fa-solid-900.woff
         fa-solid-900.woff2
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
                 "typescript": "^4.7.4"
             },
             "peerDependencies": {
-                "@fortawesome/fontawesome-free": "^6.1.1",
-                "@fortawesome/fontawesome-pro": "^6.0.0"
+                "@fortawesome/fontawesome-free": ">5.12.0",
+                "@fortawesome/fontawesome-pro": ">5.12.0"
             },
             "peerDependenciesMeta": {
                 "@fortawesome/fontawesome-free": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,63 +1,36 @@
 {
     "name": "fontawesome-subset",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "fontawesome-subset",
-            "version": "3.0.0",
+            "version": "4.0.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "lodash": ">=4.17.21",
                 "mkdirp": "^1.0.4",
-                "svg2ttf": "^6.0.3",
-                "ttf2eot": "^3.0.0",
-                "ttf2woff": "^3.0.0",
-                "ttf2woff2": "^4.0.4"
+                "subset-font": "^1.4.0",
+                "yaml": "^2.1.1"
             },
             "devDependencies": {
                 "@types/mkdirp": "^1.0.2",
                 "@types/node": "^16.9.1",
-                "@types/svg2ttf": "^5.0.1",
-                "@types/ttf2eot": "^2.0.0",
-                "@types/ttf2woff": "^2.0.2",
-                "@types/ttf2woff2": "^2.0.0",
-                "typescript": "^4.4.3"
-            }
-        },
-        "node_modules/@gar/promisify": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-            "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
-        },
-        "node_modules/@npmcli/fs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-            "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
-            "dependencies": {
-                "@gar/promisify": "^1.0.1",
-                "semver": "^7.3.5"
-            }
-        },
-        "node_modules/@npmcli/move-file": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-            "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-            "dependencies": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
+                "prettier": "^2.7.1",
+                "typescript": "^4.7.4"
             },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-            "engines": {
-                "node": ">= 6"
+            "peerDependencies": {
+                "@fortawesome/fontawesome-free": "^6.1.1",
+                "@fortawesome/fontawesome-pro": "^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@fortawesome/fontawesome-free": {
+                    "optional": true
+                },
+                "@fortawesome/fontawesome-pro": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@types/mkdirp": {
@@ -70,623 +43,34 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "16.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+            "version": "16.11.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+            "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
             "dev": true
-        },
-        "node_modules/@types/svg2ttf": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/svg2ttf/-/svg2ttf-5.0.1.tgz",
-            "integrity": "sha512-sbMTAySCMUUQYBlkfVcShKSbG9LxhGk0LdPetLak8m28WDuJhwJMVLcLzw7z/8uEyWkwtLaMxpT4R/+riYz6BA==",
-            "dev": true
-        },
-        "node_modules/@types/ttf2eot": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/ttf2eot/-/ttf2eot-2.0.0.tgz",
-            "integrity": "sha512-L8qPOoITQYiSW+ubfY2pMgY2vGTyM2tHP4rbtoq78xJpQAQcVsPJV3uC7R8fUPYMGSC1K22zXA8uQv777padrQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/ttf2woff": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/ttf2woff/-/ttf2woff-2.0.2.tgz",
-            "integrity": "sha512-I9jyTALLpz/k8d8Loz505v0obP66CrQ56uL9VJNwub1OckRGT/gQlrfKHbwy1z6w1WXQETgdiJaquCCjx9ej1A==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/ttf2woff2": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/ttf2woff2/-/ttf2woff2-2.0.0.tgz",
-            "integrity": "sha512-SK+EZ+N07Se3acZx6lc7Oa/FSoKfNrlQbtRDn5mGCJHpx1t6E6JmNRoTcjFbUdIxuG18BykEe/pPyCJhYiSu8A==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@xmldom/xmldom": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
-            "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/agentkeepalive": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-            "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
-            "dependencies": {
-                "debug": "^4.1.0",
-                "depd": "^1.1.2",
-                "humanize-ms": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
-        },
-        "node_modules/are-we-there-yet/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/are-we-there-yet/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "node_modules/are-we-there-yet/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
         },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/bufferstreams": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-3.0.0.tgz",
-            "integrity": "sha512-Qg0ggJUWJq90vtg4lDsGN9CDWvzBMQxhiEkSOD/sJfYt6BLect3eV1/S6K7SCSKJ34n60rf6U5eUPmQENVE4UA==",
-            "dependencies": {
-                "readable-stream": "^3.4.0"
-            },
-            "engines": {
-                "node": ">=8.12.0"
-            }
-        },
-        "node_modules/cacache": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-            "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-            "dependencies": {
-                "@npmcli/fs": "^1.0.0",
-                "@npmcli/move-file": "^1.0.1",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "glob": "^7.1.4",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^6.0.0",
-                "minipass": "^3.1.1",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.2",
-                "mkdirp": "^1.0.3",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^8.0.1",
-                "tar": "^6.0.2",
-                "unique-filename": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/chownr": {
+        "node_modules/fontverter": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "node_modules/core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-        },
-        "node_modules/cubic2quad": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
-            "integrity": "sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ=="
-        },
-        "node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "resolved": "https://registry.npmjs.org/fontverter/-/fontverter-2.0.0.tgz",
+            "integrity": "sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==",
             "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "wawoff2": "^2.0.0",
+                "woff2sfnt-sfnt2woff": "^1.0.0"
             }
         },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/encoding": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "optional": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
-            }
-        },
-        "node_modules/env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/err-code": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-        },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "node_modules/gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "node_modules/glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
-        "node_modules/http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "dependencies": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/humanize-ms": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-            "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-            "dependencies": {
-                "ms": "^2.0.0"
-            }
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "optional": true,
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
-        "node_modules/indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/infer-owner": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-lambda": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-            "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        "node_modules/harfbuzzjs": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.2.1.tgz",
+            "integrity": "sha512-4Tu2CiuhgZtku8cz7q2FJFASY7ITKFCjH9jZa1z8wGSXttI7cAvWBOoHbRIva8NMAKxXW5BcOB032zyL3eO4nQ=="
         },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/make-fetch-happen": {
-            "version": "8.0.14",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
-            "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
-            "dependencies": {
-                "agentkeepalive": "^4.1.3",
-                "cacache": "^15.0.5",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^6.0.0",
-                "minipass": "^3.1.3",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^1.3.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^5.0.0",
-                "ssri": "^8.0.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/microbuffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/microbuffer/-/microbuffer-1.0.0.tgz",
-            "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI="
-        },
-        "node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-            "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minipass-collect": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-            "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minipass-fetch": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-            "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-            "dependencies": {
-                "minipass": "^3.1.0",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "optionalDependencies": {
-                "encoding": "^0.1.12"
-            }
-        },
-        "node_modules/minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minipass-pipeline": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minipass-sized": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-            "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/mkdirp": {
             "version": "1.0.4",
@@ -699,94 +83,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-        },
-        "node_modules/node-gyp": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.2.0.tgz",
-            "integrity": "sha512-KG8SdcoAnw2d6augGwl1kOayALUrXW/P2uOAm2J2+nmW/HjZo7y+8TDg7LejxbekOOSv3kzhq+NSUYkIDAX8eA==",
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dependencies": {
-                "env-paths": "^2.2.0",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^8.0.14",
-                "nopt": "^5.0.0",
-                "npmlog": "^4.1.2",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-            },
-            "bin": {
-                "node-gyp": "bin/node-gyp.js"
-            },
-            "engines": {
-                "node": ">= 10.12.0"
-            }
-        },
-        "node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
-        "node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
+                "yocto-queue": "^0.1.0"
             },
             "engines": {
                 "node": ">=10"
@@ -800,280 +102,36 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
-        "node_modules/promise-inflight": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-        },
-        "node_modules/promise-retry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-            "dependencies": {
-                "err-code": "^2.0.2",
-                "retry": "^0.12.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
+        "node_modules/prettier": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "dev": true,
             "bin": {
-                "rimraf": "bin.js"
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "optional": true
-        },
-        "node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+        "node_modules/subset-font": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/subset-font/-/subset-font-1.4.0.tgz",
+            "integrity": "sha512-JdL+xscAZYYX5na+1iJCaitsf20Ek1PXpHZEP35az//OemoufKgrgh410L+Xf4naBxzLtwFeH9RWkiwimlo73A==",
             "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
-        "node_modules/smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-            "engines": {
-                "node": ">= 6.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-            "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
-            "dependencies": {
-                "ip": "^1.1.5",
-                "smart-buffer": "^4.1.0"
-            },
-            "engines": {
-                "node": ">= 10.13.0",
-                "npm": ">= 3.0.0"
-            }
-        },
-        "node_modules/socks-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
-            "dependencies": {
-                "agent-base": "^6.0.2",
-                "debug": "4",
-                "socks": "^2.3.3"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/ssri": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-            "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-            "dependencies": {
-                "minipass": "^3.1.1"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/svg2ttf": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-6.0.3.tgz",
-            "integrity": "sha512-CgqMyZrbOPpc+WqH7aga4JWkDPso23EgypLsbQ6gN3uoPWwwiLjXvzgrwGADBExvCRJrWFzAeK1bSoSpE7ixSQ==",
-            "dependencies": {
-                "@xmldom/xmldom": "^0.7.2",
-                "argparse": "^2.0.1",
-                "cubic2quad": "^1.2.1",
-                "lodash": "^4.17.10",
-                "microbuffer": "^1.0.0",
-                "svgpath": "^2.1.5"
-            },
-            "bin": {
-                "svg2ttf": "svg2ttf.js"
-            }
-        },
-        "node_modules/svgpath": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.3.0.tgz",
-            "integrity": "sha512-N/4UDu3Y2ICik0daMmFW1tplw0XPs1nVIEVYkTiQfj9/JQZeEtAKaSYwheCwje1I4pQ5r22fGpoaNIvGgsyJyg=="
-        },
-        "node_modules/tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/ttf2eot": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-3.0.0.tgz",
-            "integrity": "sha512-Y/ymhhYr/lLkf66BnLQBs3LjttPDE+1BJcFHq/oJN5SnZTacMWVdPfGLB5eIVnC2iT9gZ2ls/Bre2zbKq6hNsA==",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "ttf2eot": "ttf2eot.js"
-            }
-        },
-        "node_modules/ttf2woff": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-3.0.0.tgz",
-            "integrity": "sha512-OvmFcj70PhmAsVQKfC15XoKH55cRWuaRzvr2fpTNhTNer6JBpG8n6vOhRrIgxMjcikyYt88xqYXMMVapJ4Rjvg==",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "pako": "^1.0.0"
-            },
-            "bin": {
-                "ttf2woff": "ttf2woff.js"
-            }
-        },
-        "node_modules/ttf2woff2": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-4.0.4.tgz",
-            "integrity": "sha512-pdt/q89D6VmWToUkiwrUo/OrQtmHGr2iBl3GQriHE6xq0cnteb8gJF8UitOdXmFTX8ajKgb3HMGKpKAsCJM61g==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "bufferstreams": "^3.0.0",
-                "nan": "^2.14.2",
-                "node-gyp": "^8.1.0"
-            },
-            "bin": {
-                "ttf2woff2": "bin/ttf2woff2.js"
-            },
-            "engines": {
-                "node": ">=12"
+                "fontverter": "^2.0.0",
+                "harfbuzzjs": "^0.2.1",
+                "lodash": "^4.17.21",
+                "p-limit": "^3.1.0"
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -1083,89 +141,47 @@
                 "node": ">=4.2.0"
             }
         },
-        "node_modules/unique-filename": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+        "node_modules/wawoff2": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+            "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
             "dependencies": {
-                "unique-slug": "^2.0.0"
-            }
-        },
-        "node_modules/unique-slug": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-            "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-            "dependencies": {
-                "imurmurhash": "^0.1.4"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dependencies": {
-                "isexe": "^2.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
+                "woff2_compress.js": "bin/woff2_compress.js",
+                "woff2_decompress.js": "bin/woff2_decompress.js"
             }
         },
-        "node_modules/wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+        "node_modules/woff2sfnt-sfnt2woff": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/woff2sfnt-sfnt2woff/-/woff2sfnt-sfnt2woff-1.0.0.tgz",
+            "integrity": "sha512-edK4COc1c1EpRfMqCZO1xJOvdUtM5dbVb9iz97rScvnTevqEB3GllnLWCmMVp1MfQBdF1DFg/11I0rSyAdS4qQ==",
             "dependencies": {
-                "string-width": "^1.0.2 || 2"
+                "pako": "^1.0.7"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        "node_modules/yaml": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "engines": {
+                "node": ">= 14"
+            }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         }
     },
     "dependencies": {
-        "@gar/promisify": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-            "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw=="
-        },
-        "@npmcli/fs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.0.0.tgz",
-            "integrity": "sha512-8ltnOpRR/oJbOp8vaGUnipOi3bqkcW+sLHFlyXIr08OGHmVJLB1Hn7QtGXbYcpVtH1gAYZTlmDXtE4YV0+AMMQ==",
-            "requires": {
-                "@gar/promisify": "^1.0.1",
-                "semver": "^7.3.5"
-            }
-        },
-        "@npmcli/move-file": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-            "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-            "requires": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-            }
-        },
-        "@tootallnate/once": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
-        },
         "@types/mkdirp": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.2.tgz",
@@ -1176,598 +192,46 @@
             }
         },
         "@types/node": {
-            "version": "16.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+            "version": "16.11.41",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.41.tgz",
+            "integrity": "sha512-mqoYK2TnVjdkGk8qXAVGc/x9nSaTpSrFaGFm43BUH3IdoBV0nta6hYaGmdOvIMlbHJbUEVen3gvwpwovAZKNdQ==",
             "dev": true
-        },
-        "@types/svg2ttf": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@types/svg2ttf/-/svg2ttf-5.0.1.tgz",
-            "integrity": "sha512-sbMTAySCMUUQYBlkfVcShKSbG9LxhGk0LdPetLak8m28WDuJhwJMVLcLzw7z/8uEyWkwtLaMxpT4R/+riYz6BA==",
-            "dev": true
-        },
-        "@types/ttf2eot": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/ttf2eot/-/ttf2eot-2.0.0.tgz",
-            "integrity": "sha512-L8qPOoITQYiSW+ubfY2pMgY2vGTyM2tHP4rbtoq78xJpQAQcVsPJV3uC7R8fUPYMGSC1K22zXA8uQv777padrQ==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/ttf2woff": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/ttf2woff/-/ttf2woff-2.0.2.tgz",
-            "integrity": "sha512-I9jyTALLpz/k8d8Loz505v0obP66CrQ56uL9VJNwub1OckRGT/gQlrfKHbwy1z6w1WXQETgdiJaquCCjx9ej1A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@types/ttf2woff2": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/ttf2woff2/-/ttf2woff2-2.0.0.tgz",
-            "integrity": "sha512-SK+EZ+N07Se3acZx6lc7Oa/FSoKfNrlQbtRDn5mGCJHpx1t6E6JmNRoTcjFbUdIxuG18BykEe/pPyCJhYiSu8A==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "@xmldom/xmldom": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
-            "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw=="
-        },
-        "abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-        },
-        "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "requires": {
-                "debug": "4"
-            }
-        },
-        "agentkeepalive": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-            "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
-            "requires": {
-                "debug": "^4.1.0",
-                "depd": "^1.1.2",
-                "humanize-ms": "^1.2.1"
-            }
-        },
-        "aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "requires": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            }
-        },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
-        "are-we-there-yet": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-            "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
         },
         "argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "bufferstreams": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-3.0.0.tgz",
-            "integrity": "sha512-Qg0ggJUWJq90vtg4lDsGN9CDWvzBMQxhiEkSOD/sJfYt6BLect3eV1/S6K7SCSKJ34n60rf6U5eUPmQENVE4UA==",
-            "requires": {
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "cacache": {
-            "version": "15.3.0",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-            "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-            "requires": {
-                "@npmcli/fs": "^1.0.0",
-                "@npmcli/move-file": "^1.0.1",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "glob": "^7.1.4",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^6.0.0",
-                "minipass": "^3.1.1",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.2",
-                "mkdirp": "^1.0.3",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^8.0.1",
-                "tar": "^6.0.2",
-                "unique-filename": "^1.1.1"
-            }
-        },
-        "chownr": {
+        "fontverter": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-        },
-        "clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
-        "concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-        },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
-        "core-util-is": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-        },
-        "cubic2quad": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/cubic2quad/-/cubic2quad-1.2.1.tgz",
-            "integrity": "sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ=="
-        },
-        "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "resolved": "https://registry.npmjs.org/fontverter/-/fontverter-2.0.0.tgz",
+            "integrity": "sha512-DFVX5hvXuhi1Jven1tbpebYTCT9XYnvx6/Z+HFUPb7ZRMCW+pj2clU9VMhoTPgWKPhAs7JJDSk3CW1jNUvKCZQ==",
             "requires": {
-                "ms": "2.1.2"
+                "wawoff2": "^2.0.0",
+                "woff2sfnt-sfnt2woff": "^1.0.0"
             }
         },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-        },
-        "encoding": {
-            "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-            "optional": true,
-            "requires": {
-                "iconv-lite": "^0.6.2"
-            }
-        },
-        "env-paths": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
-        },
-        "err-code": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-            "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-        },
-        "fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "requires": {
-                "minipass": "^3.0.0"
-            }
-        },
-        "fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-        },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-            "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            }
-        },
-        "graceful-fs": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
-        },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-        },
-        "http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-        },
-        "http-proxy-agent": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-            "requires": {
-                "@tootallnate/once": "1",
-                "agent-base": "6",
-                "debug": "4"
-            }
-        },
-        "https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "requires": {
-                "agent-base": "6",
-                "debug": "4"
-            }
-        },
-        "humanize-ms": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-            "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-            "requires": {
-                "ms": "^2.0.0"
-            }
-        },
-        "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "optional": true,
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-        },
-        "indent-string": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-        },
-        "infer-owner": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
-        },
-        "inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
-        },
-        "is-lambda": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-            "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU="
-        },
-        "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        "harfbuzzjs": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-0.2.1.tgz",
+            "integrity": "sha512-4Tu2CiuhgZtku8cz7q2FJFASY7ITKFCjH9jZa1z8wGSXttI7cAvWBOoHbRIva8NMAKxXW5BcOB032zyL3eO4nQ=="
         },
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "requires": {
-                "yallist": "^4.0.0"
-            }
-        },
-        "make-fetch-happen": {
-            "version": "8.0.14",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-8.0.14.tgz",
-            "integrity": "sha512-EsS89h6l4vbfJEtBZnENTOFk8mCRpY5ru36Xe5bcX1KYIli2mkSHqoFsp5O1wMDvTJJzxe/4THpCTtygjeeGWQ==",
-            "requires": {
-                "agentkeepalive": "^4.1.3",
-                "cacache": "^15.0.5",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^4.0.1",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^6.0.0",
-                "minipass": "^3.1.3",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^1.3.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^5.0.0",
-                "ssri": "^8.0.0"
-            }
-        },
-        "microbuffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/microbuffer/-/microbuffer-1.0.0.tgz",
-            "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI="
-        },
-        "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
-        "minipass": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-            "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-            "requires": {
-                "yallist": "^4.0.0"
-            }
-        },
-        "minipass-collect": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-            "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-            "requires": {
-                "minipass": "^3.0.0"
-            }
-        },
-        "minipass-fetch": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-            "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-            "requires": {
-                "encoding": "^0.1.12",
-                "minipass": "^3.1.0",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.0.0"
-            }
-        },
-        "minipass-flush": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-            "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-            "requires": {
-                "minipass": "^3.0.0"
-            }
-        },
-        "minipass-pipeline": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-            "requires": {
-                "minipass": "^3.0.0"
-            }
-        },
-        "minipass-sized": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-            "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-            "requires": {
-                "minipass": "^3.0.0"
-            }
-        },
-        "minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "requires": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            }
-        },
         "mkdirp": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
-        "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-        },
-        "node-gyp": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.2.0.tgz",
-            "integrity": "sha512-KG8SdcoAnw2d6augGwl1kOayALUrXW/P2uOAm2J2+nmW/HjZo7y+8TDg7LejxbekOOSv3kzhq+NSUYkIDAX8eA==",
+        "p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "requires": {
-                "env-paths": "^2.2.0",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^8.0.14",
-                "nopt": "^5.0.0",
-                "npmlog": "^4.1.2",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-            }
-        },
-        "nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "requires": {
-                "abbrev": "1"
-            }
-        },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-        },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
-        "once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "requires": {
-                "wrappy": "1"
-            }
-        },
-        "p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "requires": {
-                "aggregate-error": "^3.0.0"
+                "yocto-queue": "^0.1.0"
             }
         },
         "pako": {
@@ -1775,251 +239,54 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
             "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
-        "path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        "prettier": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "dev": true
         },
-        "process-nextick-args": {
+        "subset-font": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/subset-font/-/subset-font-1.4.0.tgz",
+            "integrity": "sha512-JdL+xscAZYYX5na+1iJCaitsf20Ek1PXpHZEP35az//OemoufKgrgh410L+Xf4naBxzLtwFeH9RWkiwimlo73A==",
+            "requires": {
+                "fontverter": "^2.0.0",
+                "harfbuzzjs": "^0.2.1",
+                "lodash": "^4.17.21",
+                "p-limit": "^3.1.0"
+            }
+        },
+        "typescript": {
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+            "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+            "dev": true
+        },
+        "wawoff2": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
-        "promise-inflight": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-        },
-        "promise-retry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
-            "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-            "requires": {
-                "err-code": "^2.0.2",
-                "retry": "^0.12.0"
-            }
-        },
-        "readable-stream": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            }
-        },
-        "retry": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-        },
-        "rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "requires": {
-                "glob": "^7.1.3"
-            }
-        },
-        "safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "optional": true
-        },
-        "semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-        },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
-        "smart-buffer": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-        },
-        "socks": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-            "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
-            "requires": {
-                "ip": "^1.1.5",
-                "smart-buffer": "^4.1.0"
-            }
-        },
-        "socks-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
-            "requires": {
-                "agent-base": "^6.0.2",
-                "debug": "4",
-                "socks": "^2.3.3"
-            }
-        },
-        "ssri": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-            "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-            "requires": {
-                "minipass": "^3.1.1"
-            }
-        },
-        "string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "requires": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            }
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
-        "svg2ttf": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/svg2ttf/-/svg2ttf-6.0.3.tgz",
-            "integrity": "sha512-CgqMyZrbOPpc+WqH7aga4JWkDPso23EgypLsbQ6gN3uoPWwwiLjXvzgrwGADBExvCRJrWFzAeK1bSoSpE7ixSQ==",
-            "requires": {
-                "@xmldom/xmldom": "^0.7.2",
-                "argparse": "^2.0.1",
-                "cubic2quad": "^1.2.1",
-                "lodash": "^4.17.10",
-                "microbuffer": "^1.0.0",
-                "svgpath": "^2.1.5"
-            }
-        },
-        "svgpath": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.3.0.tgz",
-            "integrity": "sha512-N/4UDu3Y2ICik0daMmFW1tplw0XPs1nVIEVYkTiQfj9/JQZeEtAKaSYwheCwje1I4pQ5r22fGpoaNIvGgsyJyg=="
-        },
-        "tar": {
-            "version": "6.1.11",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-            "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-            "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            }
-        },
-        "ttf2eot": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ttf2eot/-/ttf2eot-3.0.0.tgz",
-            "integrity": "sha512-Y/ymhhYr/lLkf66BnLQBs3LjttPDE+1BJcFHq/oJN5SnZTacMWVdPfGLB5eIVnC2iT9gZ2ls/Bre2zbKq6hNsA==",
+            "resolved": "https://registry.npmjs.org/wawoff2/-/wawoff2-2.0.1.tgz",
+            "integrity": "sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==",
             "requires": {
                 "argparse": "^2.0.1"
             }
         },
-        "ttf2woff": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ttf2woff/-/ttf2woff-3.0.0.tgz",
-            "integrity": "sha512-OvmFcj70PhmAsVQKfC15XoKH55cRWuaRzvr2fpTNhTNer6JBpG8n6vOhRrIgxMjcikyYt88xqYXMMVapJ4Rjvg==",
+        "woff2sfnt-sfnt2woff": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/woff2sfnt-sfnt2woff/-/woff2sfnt-sfnt2woff-1.0.0.tgz",
+            "integrity": "sha512-edK4COc1c1EpRfMqCZO1xJOvdUtM5dbVb9iz97rScvnTevqEB3GllnLWCmMVp1MfQBdF1DFg/11I0rSyAdS4qQ==",
             "requires": {
-                "argparse": "^2.0.1",
-                "pako": "^1.0.0"
+                "pako": "^1.0.7"
             }
         },
-        "ttf2woff2": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/ttf2woff2/-/ttf2woff2-4.0.4.tgz",
-            "integrity": "sha512-pdt/q89D6VmWToUkiwrUo/OrQtmHGr2iBl3GQriHE6xq0cnteb8gJF8UitOdXmFTX8ajKgb3HMGKpKAsCJM61g==",
-            "requires": {
-                "bindings": "^1.5.0",
-                "bufferstreams": "^3.0.0",
-                "nan": "^2.14.2",
-                "node-gyp": "^8.1.0"
-            }
+        "yaml": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
         },
-        "typescript": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-            "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
-            "dev": true
-        },
-        "unique-filename": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-            "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-            "requires": {
-                "unique-slug": "^2.0.0"
-            }
-        },
-        "unique-slug": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-            "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-            "requires": {
-                "imurmurhash": "^0.1.4"
-            }
-        },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-        },
-        "which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "requires": {
-                "isexe": "^2.0.0"
-            }
-        },
-        "wide-align": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-            "requires": {
-                "string-width": "^1.0.2 || 2"
-            }
-        },
-        "wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        "yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "optimize"
     ],
     "peerDependencies": {
-        "@fortawesome/fontawesome-free": "^6.1.1",
-        "@fortawesome/fontawesome-pro": "^6.0.0"
+        "@fortawesome/fontawesome-free": ">5.12.0",
+        "@fortawesome/fontawesome-pro": ">5.12.0"
     },
     "peerDependenciesMeta": {
         "@fortawesome/fontawesome-free": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fontawesome-subset",
-    "version": "3.0.0",
+    "version": "4.0.0",
     "description": "Utility to create subsets for FontAwesome and FontAwesome Pro.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -21,10 +21,8 @@
     "dependencies": {
         "lodash": ">=4.17.21",
         "mkdirp": "^1.0.4",
-        "svg2ttf": "^6.0.3",
-        "ttf2eot": "^3.0.0",
-        "ttf2woff": "^3.0.0",
-        "ttf2woff2": "^4.0.4"
+        "subset-font": "^1.4.0",
+        "yaml": "^2.1.1"
     },
     "license": "GPL-3.0-or-later",
     "repository": {
@@ -41,13 +39,22 @@
         "icon font",
         "optimize"
     ],
+    "peerDependencies": {
+        "@fortawesome/fontawesome-free": "^6.1.1",
+        "@fortawesome/fontawesome-pro": "^6.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@fortawesome/fontawesome-free": {
+            "optional": true
+        },
+        "@fortawesome/fontawesome-pro": {
+            "optional": true
+        }
+    },
     "devDependencies": {
         "@types/mkdirp": "^1.0.2",
         "@types/node": "^16.9.1",
-        "@types/svg2ttf": "^5.0.1",
-        "@types/ttf2eot": "^2.0.0",
-        "@types/ttf2woff": "^2.0.2",
-        "@types/ttf2woff2": "^2.0.0",
-        "typescript": "^4.4.3"
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.4"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ function fontawesomeSubset(subset: SubsetOption, outputDir: string, options: Fon
     const fontTypes = Object.keys(fontMap);
 
     // Check to see if the user has either free, or pro installed.
-    if (!(existsSync("node_modules/@fortawesome/fontawesome-free") || existsSync("node_modules/@fortawesome/fontawesome-pro"))) {
+    if (!(existsSync(require.resolve("@fortawesome/fontawesome-free")) || existsSync(require.resolve("@fortawesome/fontawesome-pro")))) {
         console.error("Unable to find either the Free or Pro FontAwesome files in node_modules folder. Double-check that you have your preferred fontawesome package as a dependency in `package.json` and rerun the installation.");
         return;
     }
@@ -87,14 +87,14 @@ function fontawesomeSubset(subset: SubsetOption, outputDir: string, options: Fon
 
         const fontFamily = key as keyof typeof fontMap;
         const svgFileName = fontMap[fontFamily];
-        const svgFilePath = `node_modules/@fortawesome/fontawesome-${options.package}/webfonts/${svgFileName}.svg`;
+        const svgFilePath = `@fortawesome/fontawesome-${options.package}/webfonts/${svgFileName}.svg`;
 
-        if (!existsSync(svgFilePath)) {
+        if (!existsSync(require.resolve(svgFilePath))) {
             console.warn(`Unable to find SVG font file for requested font style '${fontFamily}'. Skipping.`);
             continue;
         }
 
-        const svgFile = readFileSync(svgFilePath).toString();
+        const svgFile = readFileSync(require.resolve(svgFilePath)).toString();
         const glyphsToRemove = findGlyphsToRemove(svgFile, fontFamily, icons);
         const svgContentsNew = svgFile.replace(new RegExp(`(<glyph glyph-name="(${glyphsToRemove.join("|")})".*?\\/>)`, "gms"), "").replace(/>\s+</gms, "><");
         const ttfUtils = svg2ttf(svgContentsNew, {
@@ -119,4 +119,4 @@ function fontawesomeSubset(subset: SubsetOption, outputDir: string, options: Fon
 }
 
 export { fontawesomeSubset };
-export * from "./types";
+export { FontAwesomeOptions, Subset, SubsetOption, GlyphName } from "./types";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true
     },
-    "include": ["src"],
+    "include": [
+        "src",
+        "types"
+    ],
     "exclude": ["node_modules"]
 }

--- a/types/subset-font.d.ts
+++ b/types/subset-font.d.ts
@@ -1,5 +1,5 @@
 declare module "subset-font" {
-    export type TargetFormat = 'sfnt' | 'woff' | 'woff2' | 'truetype';
+    export type TargetFormat = "sfnt" | "woff" | "woff2" | "truetype";
 
     export interface SubsetFontOptions {
         targetFormat?: TargetFormat;

--- a/types/subset-font.d.ts
+++ b/types/subset-font.d.ts
@@ -1,0 +1,12 @@
+declare module "subset-font" {
+    export type TargetFormat = 'sfnt' | 'woff' | 'woff2' | 'truetype';
+
+    export interface SubsetFontOptions {
+        targetFormat?: TargetFormat;
+        preserveNameIds?: number[];
+    }
+
+    function subsetFont(buffer: Buffer, text: string, options: SubsetFontOptions): Promise<Buffer>;
+
+    export = subsetFont;
+}


### PR DESCRIPTION
Heavily inspired by the work done in #19, @saurori and @christopherpickering, with some refinements & refactoring to be more closely matched to the original code. Refactors the library to use `subset-font` underneath and extract glyphs based on icon names and merge them into separate fonts. This should allow versions `>=5.12.0` -- including `6.0+`. Reduced font outputs to `ttf` and `woff2` only following FA's lead. Also includes fixes for Duotone icons.
 
Closes #15 
Closes #16
Closes #17