### PR TITLE
feat: alias names

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,11 @@ export interface FAIconType {
      * Subsets this icon is available in.
      */
     styles: Partial<Subset>[];
+
+    /** Alternative names of the icon. */
+    aliases?: {
+        names?: string[]
+    }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,19 @@ import { IconYAML, Subset } from "./types";
 /**
  * Find an icon using the IconYAML provided by FontAwesome.
  */
-export function findIconByName(yaml: IconYAML, iconName: string) {
-    return yaml[iconName];
-}
+ export function findIconByName(yaml: IconYAML, iconName: string) {
+    const icon = yaml[iconName];
+    if (icon) {
+      return icon;
+    }
+    const keyForAlias = Object.keys(yaml).find((k) =>
+      yaml[k]?.aliases?.names?.includes(iconName)
+    );
+    if (keyForAlias) {
+      return yaml[keyForAlias];
+    }
+    return undefined;
+  }
 
 /**
  * Add an icon to the debug / warning error report.

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -37,6 +37,13 @@ describe("findIconByName", () => {
         expect(icon?.unicode).toEqual("2b");
         expect(icon?.styles).toEqual(["solid"]);
     });
+
+    it("should find an icon by an alias name", () => {
+        const icon = findIconByName(iconMetadata, "add");
+        expect(icon).toBeTruthy();
+        expect(icon?.unicode).toEqual("2b");
+        expect(icon?.styles).toEqual(["solid"]);
+    });
 });
 
 describe("addIconError", () => {


### PR DESCRIPTION
The subset generator doesn't work if you use alias names. Our designers use them and I don't want to change all the templates. Also, it is often more semantic to use aliases, so I think it makes sense to support this feature.

I've added a simple search for aliases if an icon isn't found directly.