### PR TITLE
packagePath

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,15 +35,22 @@ function fontawesomeSubset(
     const { package: packageType = "free", targetFormats = ["woff2", "sfnt"] } = options;
     // Maps style to actual font name / file name.
     const fontTypes = Object.keys(STYLE_FONT_MAP);
-    let packageLocation: string;
 
+    let packagePath;
+    if(options.packagepath) {
+       packagePath = options.packagepath;
+    }
+    else{
+        packagePath = `@fortawesome/fontawesome-${packageType}`; 
+    }
+
+    let packageLocation;
     // Check to see if the user has either free, or pro installed.
     try {
-        packageLocation = require.resolve(`@fortawesome/fontawesome-${packageType}`);
-    } catch (e) {
-        console.error(
-            `Unable to resolve the module '@fortawesome/fontawesome-${packageType}'. Double-check that you have your preferred fontawesome package installed as a dependency and the package type passed into the options if using Pro features.\n\n\`fontawesomeSubset(..., ..., { package: 'pro' })\``
-        );
+        packageLocation = require.resolve(packagePath);
+    }
+    catch (e) {
+        console.error(`Unable to resolve the module '${packagePath}'. Double-check that you have your preferred fontawesome package installed as a dependency and the package type passed into the options if using Pro features.\n\n\`fontawesomeSubset(..., ..., { package: 'pro' })\``);
         return Promise.resolve(false);
     }
 


### PR DESCRIPTION
- I've installed font-awesome using the following commands
```npm install fontawesome-pro-5@npm:@fortawesome/fontawesome-pro@5.15.4```
```npm install fontawesome-pro-6@npm:@fortawesome/fontawesome-pro@6.4.0```
- this means my package is not located at ```@fortawesome/fontawesome-pro```
- I've tried adding the option ```{"package": "pro-6" }``` but look like `PackageType` is also used elsewhere in the code